### PR TITLE
Test CI build artifacts link PR

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -2,6 +2,9 @@ name: 🤖 Android Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -2,6 +2,9 @@ name: 🍏 iOS Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -2,6 +2,9 @@ name: 🐧 Linux Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -2,6 +2,9 @@ name: 🍎 macOS Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/pr_artifacts.yml
+++ b/.github/workflows/pr_artifacts.yml
@@ -1,0 +1,67 @@
+name: Link PR artifacts pr_artifacts.yml
+on:
+  workflow_run:
+    workflows:
+      - 🔗 GHA
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pr-artifacts:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - id: pr-number
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const {owner, repo} = context.repo;
+            const pullHeadSHA = '${{github.event.workflow_run.head_sha}}';
+            const pullUserId = ${{github.event.sender.id}};
+            const prNumber = await (async () => {
+              const pulls = await github.rest.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pullHeadSHA && pull.user.id === pullUserId) {
+                    return pull.number;
+                  }
+                }
+              }
+            })();
+
+            if (!prNumber) {
+              return core.error(`No matching pull request found`);
+            }
+
+            return prNumber;
+
+      - id: artifacts-text
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+
+            return allArtifacts.data.artifacts.reduce((acc, item) => {
+              if (item.name === "assets") return acc;
+              acc += `
+              - [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
+              return acc;
+            }, '### Build artifacts');
+
+      - id: add-to-pr
+        uses: garrettjoecox/pr-section@3.1.0
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          pr-number: ${{ steps.pr-number.outputs.result }}
+          section-name: artifacts
+          section-value: '${{ steps.artifacts-text.outputs.result }}'

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,6 +1,9 @@
 name: 🔗 GHA
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-runner
   cancel-in-progress: true

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -2,6 +2,9 @@ name: 📊 Static Checks
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
   cancel-in-progress: true

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -2,6 +2,9 @@ name: 🌐 Web Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -2,6 +2,9 @@ name: 🏁 Windows Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
 env:

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2552,6 +2552,8 @@ void ProjectManager::_version_button_pressed() {
 ProjectManager::ProjectManager() {
 	singleton = this;
 
+	print_line("Hello from CI build! This is a force push with permission changes to CI.");
+
 	// load settings
 	if (!EditorSettings::get_singleton()) {
 		EditorSettings::create();


### PR DESCRIPTION
See https://github.com/garrettjoecox/pr-section/issues/1.

**Note:** Pushing a new build. If this works correctly, once workflows have completed, `Hello from CI build! This is a force push.` should be printed in stdout when running the project manager from a terminal.

<!--- section:artifacts:start -->
### Build artifacts
  - [android-template.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214227.zip)
  - [ios-template.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214228.zip)
  - [linux-editor-mono.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214229.zip)
  - [linux-template-minimal.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214230.zip)
  - [linux-template-mono.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214231.zip)
  - [macos-editor.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214232.zip)
  - [macos-template.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214233.zip)
  - [web-template.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214234.zip)
  - [windows-editor.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214235.zip)
  - [windows-template.zip](https://nightly.link/Calinou/godot-ci-temp-test/actions/artifacts/682214237.zip)
<!--- section:artifacts:end -->